### PR TITLE
12 display of company on the same line in footer

### DIFF
--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -562,7 +562,7 @@ function HomeFooter() {
       </div>
     </div>
     <div className={clsx(styles.footer, styles.flex, styles.justifyCenter)}>
-      <div className={clsx(styles.h_w, styles.flex, styles.flexWrap, styles.footerContent)}>
+      <div className={clsx(styles.flex, styles.flexWrap, styles.footerContent)}>
         <div className={styles.half}>
           <span>Powered by NaasAI Inc. © 2023</span>
           <ul className={clsx(styles.flex, styles.flexWrap)}>

--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -731,6 +731,7 @@ p {
 .footer ul {
   list-style: none;
   padding: 0;
+  margin-top: 10px;
 }
 
 .footer li {

--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -724,11 +724,13 @@ p {
   padding: 30px;
 }
 
+.footer span {
+  color: #fff;
+}
+
 .footer ul {
   list-style: none;
   padding: 0;
-  /* margin: 10px 0px; */
-  margin: 2px 40px 10px 0px;
 }
 
 .footer li {
@@ -745,6 +747,10 @@ p {
 
 .footer strong {
   color: #fff;
+}
+
+.footerContent {
+  width: 100%;
 }
 
 


### PR DESCRIPTION
Closes #12 .

Removed the margin so that the footer links are aligned horizontally when there is space available.


![12-display-of-company-on-the-same-line-in-footer](https://github.com/jupyter-naas/site/assets/130969350/450d6824-c028-49f2-b2b7-45a10825bbd7)
